### PR TITLE
pysimdjson 6.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   # Upstream does not support python 3.13 for this version,
-  # which is needed for the latest pystan
+  # which is needed for pystan 3.10.0
   skip: true  # [py<39 or py>=313]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pysimdjson" %}
-{% set version = "6.0.2" %}
+{% set version = "7.0.1" %}
 
 
 package:
@@ -8,12 +8,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ddbd6fecd42aa01c5c87d3c79b8ede1885b6763337d21745587a5392572c1f45
+  sha256: da6a23d8cbb9096d41fe6db2906ab6e6c0a2f42a652c9781eaf052049fe8783f
 
 build:
   number: 0
-  # Upstream does not support 3.13
-  skip: true  # [py>=313]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,9 @@ source:
   sha256: ddbd6fecd42aa01c5c87d3c79b8ede1885b6763337d21745587a5392572c1f45
 
 build:
-  number: 1
-  skip: true  # [py<36]
+  number: 0
+  # Upstream does not support 3.13
+  skip: true  # [py>=313]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pysimdjson" %}
-{% set version = "7.0.1" %}
+{% set version = "6.0.2" %}
 
 
 package:
@@ -8,11 +8,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: da6a23d8cbb9096d41fe6db2906ab6e6c0a2f42a652c9781eaf052049fe8783f
+  sha256: ddbd6fecd42aa01c5c87d3c79b8ede1885b6763337d21745587a5392572c1f45
 
 build:
   number: 0
-  skip: true  # [py<39]
+  # Upstream does not support python 3.13 for this version
+  skip: true  # [py<39 or py>=313]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,11 @@ requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - pip
     - python
-    - cython
     - wheel
     - setuptools
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,10 +46,10 @@ about:
     Python bindings for the simdjson project, a SIMD-accelerated JSON parser.
     If SIMD instructions are unavailable a fallback parser is used, making pysimdjson safe to use anywhere.
   license_file: LICENSE
-  license: Apache-2.0 OR MIT
+  license: Apache-2.0 AND MIT
   license_family: Other
-  doc_url: https://github.com/TkTech/pysimdjson
-  dev_url: https://pysimdjson.tkte.ch/
+  dev_url: https://github.com/TkTech/pysimdjson
+  doc_url: https://pysimdjson.tkte.ch/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,10 +39,16 @@ test:
     - pip
 
 about:
-  home: http://github.com/TkTech/pysimdjson
+  home: https://github.com/TkTech/pysimdjson
   summary: simdjson bindings for python
+  description: |
+    Python bindings for the simdjson project, a SIMD-accelerated JSON parser.
+    If SIMD instructions are unavailable a fallback parser is used, making pysimdjson safe to use anywhere.
   license_file: LICENSE
-  license: Apache-2.0 and MIT
+  license: Apache-2.0 OR MIT
+  license_family: Other
+  doc_url: https://github.com/TkTech/pysimdjson
+  dev_url: https://pysimdjson.tkte.ch/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 
 build:
   number: 0
-  # Upstream does not support python 3.13 for this version
+  # Upstream does not support python 3.13 for this version,
+  # which is needed for the latest pystan
   skip: true  # [py<39 or py>=313]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pysimdjson" %}
-{% set version = "5.0.2" %}
+{% set version = "6.0.2" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 83010f07f9ca38e4557b61860acfeb0a897b416f06f73182ffaffa94bdb7394d
+  sha256: ddbd6fecd42aa01c5c87d3c79b8ede1885b6763337d21745587a5392572c1f45
 
 build:
   number: 1
@@ -27,6 +27,7 @@ requirements:
     - python
     - cython
     - wheel
+    - setuptools
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 1
   skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -26,6 +26,7 @@ requirements:
     - pip
     - python
     - cython
+    - wheel
   run:
     - python
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8271](https://anaconda.atlassian.net/browse/PKG-8271)
- [Upstream repository](https://github.com/TkTech/pysimdjson/tree/v6.0.2)
- [Upstream changelog/diff](https://github.com/TkTech/pysimdjson/blob/v6.0.2/CHANGELOG.md)
- Relevant dependency PRs:
  - `pysimdjson` ➡️ `pystan`

### Explanation of changes:

- BUILDING THIS VERSION TO SATISFY [PYSTAN PINNING](https://github.com/stan-dev/pystan/blob/cdd7b5f5296e01be0c9af7a8457ffc3c2ce6175b/pyproject.toml#L28)
- Skipping python 3.13 build
- Modernize recipe and update build script
- About section updates


[PKG-8271]: https://anaconda.atlassian.net/browse/PKG-8271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ